### PR TITLE
feat: Add per-application margin settings

### DIFF
--- a/src/AutoCursorLock.App/Models/BorderDimensionsExtensions.cs
+++ b/src/AutoCursorLock.App/Models/BorderDimensionsExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) James La Novara-Gsell. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace AutoCursorLock.App.Models;
+
+using AutoCursorLock.Native;
+using AutoCursorLock.Sdk.Models;
+
+/// <summary>
+/// Extensions for <see cref="BorderDimensions"/>.
+/// </summary>
+internal static class BorderDimensionsExtensions
+{
+    /// <summary>
+    /// Applies a margin to the border dimensions.
+    /// </summary>
+    /// <param name="dimensions">The dimensions to adjust.</param>
+    /// <param name="margin">The margin to apply.</param>
+    /// <returns>The adjusted dimensions.</returns>
+    public static BorderDimensions ApplyMargin(this BorderDimensions dimensions, AppLockMargin margin)
+    {
+        return new BorderDimensions(
+            dimensions.Top + margin.Top,
+            dimensions.Bottom - margin.Bottom,
+            dimensions.Left + margin.Left,
+            dimensions.Right - margin.Right
+        );
+    }
+}

--- a/src/AutoCursorLock.App/Models/ProcessListItem.cs
+++ b/src/AutoCursorLock.App/Models/ProcessListItem.cs
@@ -18,12 +18,14 @@ public record ProcessListItem
     /// <param name="name">The name of the process.</param>
     /// <param name="path">The path of the proceess' executable.</param>
     /// <param name="appLockType">The type of app lock.</param>
+    /// <param name="margin">The margin around the window for the app lock.</param>
     /// <param name="icon">The icon image of the process.</param>
-    public ProcessListItem(string name, string? path, AppLockType appLockType, BitmapSource? icon)
+    public ProcessListItem(string name, string? path, AppLockType appLockType, AppLockMargin? margin, BitmapSource? icon)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         Path = path;
         AppLockType = appLockType;
+        Margin = margin ?? new AppLockMargin(0, 0, 0, 0);
         Icon = icon;
     }
 
@@ -41,6 +43,11 @@ public record ProcessListItem
     /// Gets the type of app lock.
     /// </summary>
     public AppLockType AppLockType { get; init; }
+
+    /// <summary>
+    /// Gets the margin around the window for the app lock.
+    /// </summary>
+    public AppLockMargin Margin { get; init; }
 
     /// <summary>
     /// Gets the icon image of the process.

--- a/src/AutoCursorLock.App/Models/UserSettingsExtensions.cs
+++ b/src/AutoCursorLock.App/Models/UserSettingsExtensions.cs
@@ -27,15 +27,7 @@ public static class UserSettingsExtensions
         {
             try
             {
-                ProcessListItem processListItem;
-                if (File.Exists(appLock.Path))
-                {
-                    processListItem = ProcessListItemExtensions.FromNameAndPath(appLock.Name, appLock.Path);
-                }
-                else
-                {
-                    processListItem = ProcessListItemExtensions.FromNameAndPath(appLock.Name, default);
-                }
+                var processListItem = ProcessListItemExtensions.FromAppLockSettings(appLock);
 
                 processes.Add(processListItem);
             }

--- a/src/AutoCursorLock.App/Views/AppLockSettingsWindow.xaml
+++ b/src/AutoCursorLock.App/Views/AppLockSettingsWindow.xaml
@@ -5,9 +5,13 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:AutoCursorLock.App.Views"
         mc:Ignorable="d"
-        Title="App Lock Settings" Height="200" Width="600">
+        Title="App Lock Settings" Height="300" Width="600">
     <Grid x:Name="mainGrid">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -40,5 +44,49 @@
             MinWidth="80"
             ItemsSource="{Binding AppLockTypeOptions}" 
             SelectedItem="{Binding AppLockSettings.AppLockType}" />
+        <TextBlock
+            Grid.Column="0"
+            Grid.Row="1">
+            Left-side margin
+        </TextBlock>
+        <TextBox
+            Grid.Column="1"
+            Grid.Row="1"
+            Margin="5"
+            MinWidth="80"
+            Text="{Binding AppLockSettings.Margin.Left}" />
+        <TextBlock
+            Grid.Column="0"
+            Grid.Row="2">
+            Top-side margin
+        </TextBlock>
+        <TextBox
+            Grid.Column="1"
+            Grid.Row="2"
+            Margin="5"
+            MinWidth="80"
+            Text="{Binding AppLockSettings.Margin.Top}" />
+        <TextBlock
+            Grid.Column="0"
+            Grid.Row="3">
+            Right-side margin
+        </TextBlock>
+        <TextBox
+            Grid.Column="1"
+            Grid.Row="3"
+            Margin="5"
+            MinWidth="80"
+            Text="{Binding AppLockSettings.Margin.Right}" />
+        <TextBlock
+            Grid.Column="0"
+            Grid.Row="4">
+            Bottom-side margin
+        </TextBlock>
+        <TextBox
+            Grid.Column="1"
+            Grid.Row="4"
+            Margin="5"
+            MinWidth="80"
+            Text="{Binding AppLockSettings.Margin.Bottom}" />
     </Grid>
 </Window>

--- a/src/AutoCursorLock.App/Views/MainWindow.xaml.cs
+++ b/src/AutoCursorLock.App/Views/MainWindow.xaml.cs
@@ -213,6 +213,12 @@ public partial class MainWindow : Window, INotifyPropertyChanged
                 AppLockType.Monitor => ApplicationHandler.GetMonitorBorders(hwnd),
                 _ => throw new NotImplementedException("Invalid AppLockType")
             };
+
+            if (ActiveProcess.Margin is not null)
+            {
+                border = border.ApplyMargin(ActiveProcess.Margin);
+            }
+
             if (!MouseHandler.LockCursorToBorder(border))
             {
                 this.logger.LogError("Lock cursor error code {ErrorCode}", Marshal.GetLastWin32Error());
@@ -304,7 +310,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             {
                 if (p.MainWindowHandle != IntPtr.Zero && p.MainModule?.FileName != null)
                 {
-                    var process = ProcessListItemExtensions.FromNameAndPath(p.ProcessName, p.MainModule.FileName);
+                    var process = ProcessListItemExtensions.FromAppLockSettings(AppLockSettingsModel.FromNameAndPath(p.ProcessName, p.MainModule.FileName));
                     Processes.Add(process);
                 }
             }
@@ -314,7 +320,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
 
                 try
                 {
-                    var process = ProcessListItemExtensions.FromNameAndPath(p.ProcessName, null);
+                    var process = ProcessListItemExtensions.FromAppLockSettings(AppLockSettingsModel.FromNameAndPath(p.ProcessName, path: null));
                     Processes.Add(process);
                 }
                 catch (Exception ex2)

--- a/src/AutoCursorLock.Sdk/Models/AppLockMargin.cs
+++ b/src/AutoCursorLock.Sdk/Models/AppLockMargin.cs
@@ -1,0 +1,18 @@
+// Copyright (c) James La Novara-Gsell. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace AutoCursorLock.Sdk.Models;
+
+/// <summary>
+/// Represents the margin around a window for an app lock.
+/// </summary>
+/// <param name="Left">The left-side margin.</param>
+/// <param name="Top">The top-side margin.</param>
+/// <param name="Right">The right-side margin.</param>
+/// <param name="Bottom">THe bottom-side margin.</param>
+public record AppLockMargin(
+    int Left,
+    int Top,
+    int Right,
+    int Bottom
+);

--- a/src/AutoCursorLock.Sdk/Models/AppLockSettingsModel.cs
+++ b/src/AutoCursorLock.Sdk/Models/AppLockSettingsModel.cs
@@ -9,8 +9,22 @@ namespace AutoCursorLock.Sdk.Models;
 /// <param name="Name">The name of the process.</param>
 /// <param name="Path">The path to the application.</param>
 /// <param name="Type">The type of app lock to use.</param>
+/// <param name="Margin">The margin around the window for the app lock.</param>
 public record AppLockSettingsModel(
     string Name,
     string? Path,
-    AppLockType Type
-);
+    AppLockType Type,
+    AppLockMargin? Margin
+)
+{
+    /// <summary>
+    /// Creates an <see cref="AppLockSettingsModel"/> from the name and path, using defaults for other properties.
+    /// </summary>
+    /// <param name="name">The name of the app.</param>
+    /// <param name="path">The path to the app.</param>
+    /// <returns>The model.</returns>
+    public static AppLockSettingsModel FromNameAndPath(string name, string? path)
+    {
+        return new AppLockSettingsModel(name, path, AppLockType.Window, new AppLockMargin(0, 0, 0, 0));
+    }
+}


### PR DESCRIPTION
You can now specify a margin for the cursor lock for each application. Use this if the borders are slightly off and need to be manually adjusted.

![image](https://github.com/user-attachments/assets/f0699118-ba78-438c-8f14-b6302975e58a)

Closes #24