### PR TITLE
feat: Option to start AutoCursorLock when Windows starts

### DIFF
--- a/src/AutoCursorLock.App/MinimizeToTray.cs
+++ b/src/AutoCursorLock.App/MinimizeToTray.cs
@@ -13,86 +13,89 @@ namespace AutoCursorLock
     /// <summary>
     /// Class implementing support for "minimize to tray" functionality.
     /// </summary>
-    public static class MinimizeToTray
+    public class MinimizeToTray
     {
+        private readonly Window window;
+        private NotifyIcon? notifyIcon;
+        private bool balloonShown;
+
         /// <summary>
-        /// Enables "minimize to tray" behavior for the specified Window.
+        /// Initializes a new instance of the <see cref="MinimizeToTray"/> class.
         /// </summary>
-        /// <param name="window">Window to enable the behavior for.</param>
-        public static void Enable(Window window)
+        /// <param name="window">Window instance to attach to.</param>
+        public MinimizeToTray(Window window)
         {
-            // No need to track this instance; its event handlers will keep it alive
-            new MinimizeToTrayInstance(window);
+            Debug.Assert(window != null, "window parameter is null.");
+            this.window = window;
+        }
+
+        public void StartWatching()
+        {
+            this.window.StateChanged += new EventHandler(HandleStateChanged);
         }
 
         /// <summary>
-        /// Class implementing "minimize to tray" functionality for a Window instance.
+        /// Handles the Window's StateChanged event.
         /// </summary>
-        private class MinimizeToTrayInstance
+        /// <param name="sender">Event source.</param>
+        /// <param name="e">Event arguments.</param>
+        private void HandleStateChanged(object? sender, EventArgs e)
         {
-            private Window window;
-            private NotifyIcon? notifyIcon;
-            private bool balloonShown;
+            UpdateTrayState(showBalloon: true);
+        }
 
-            /// <summary>
-            /// Initializes a new instance of the <see cref="MinimizeToTrayInstance"/> class.
-            /// </summary>
-            /// <param name="window">Window instance to attach to.</param>
-            public MinimizeToTrayInstance(Window window)
+        public void UpdateTrayState(bool showBalloon = true)
+        {
+            if (this.notifyIcon == null)
             {
-                Debug.Assert(window != null, "window parameter is null.");
-                this.window = window;
-                this.window.StateChanged += new EventHandler(HandleStateChanged);
-            }
+                var icon = Assembly.GetEntryAssembly()?.Location;
 
-            /// <summary>
-            /// Handles the Window's StateChanged event.
-            /// </summary>
-            /// <param name="sender">Event source.</param>
-            /// <param name="e">Event arguments.</param>
-            private void HandleStateChanged(object? sender, EventArgs e)
-            {
-                if (this.notifyIcon == null)
+                // Initialize NotifyIcon instance "on demand"
+                this.notifyIcon = new NotifyIcon();
+
+                if (icon != null)
                 {
-                    var icon = Assembly.GetEntryAssembly()?.Location;
-
-                    // Initialize NotifyIcon instance "on demand"
-                    this.notifyIcon = new NotifyIcon();
-
-                    if (icon != null)
-                    {
-                        this.notifyIcon.Icon = Icon.ExtractAssociatedIcon(icon);
-                    }
-
-                    this.notifyIcon.MouseClick += new MouseEventHandler(HandleNotifyIconOrBalloonClicked);
-                    this.notifyIcon.BalloonTipClicked += new EventHandler(HandleNotifyIconOrBalloonClicked);
+                    this.notifyIcon.Icon = Icon.ExtractAssociatedIcon(icon);
                 }
 
-                // Update copy of Window Title in case it has changed
-                this.notifyIcon.Text = this.window.Title;
-
-                // Show/hide Window and NotifyIcon
-                var minimized = this.window.WindowState == WindowState.Minimized;
-                this.window.ShowInTaskbar = !minimized;
-                this.notifyIcon.Visible = minimized;
-                if (minimized && !this.balloonShown)
-                {
-                    // If this is the first time minimizing to the tray, show the user what happened
-                    this.notifyIcon.ShowBalloonTip(1000, this.window.Title, "Minimized to tray...", ToolTipIcon.None);
-                    this.balloonShown = true;
-                }
+                this.notifyIcon.MouseClick += new MouseEventHandler(HandleNotifyIconOrBalloonClicked);
+                this.notifyIcon.BalloonTipClicked += new EventHandler(HandleNotifyIconOrBalloonClicked);
             }
 
-            /// <summary>
-            /// Handles a click on the notify icon or its balloon.
-            /// </summary>
-            /// <param name="sender">Event source.</param>
-            /// <param name="e">Event arguments.</param>
-            private void HandleNotifyIconOrBalloonClicked(object? sender, EventArgs e)
+            // Update copy of Window Title in case it has changed
+            this.notifyIcon.Text = this.window.Title;
+
+            // Show/hide Window and NotifyIcon
+            var minimized = this.window.WindowState == WindowState.Minimized;
+            this.window.ShowInTaskbar = !minimized;
+            this.notifyIcon.Visible = minimized;
+            if (showBalloon && minimized && !this.balloonShown)
             {
-                // Restore the Window
-                this.window.WindowState = WindowState.Normal;
+                // If this is the first time minimizing to the tray, show the user what happened
+                this.notifyIcon.ShowBalloonTip(1000, this.window.Title, "Minimized to tray...", ToolTipIcon.None);
+                this.balloonShown = true;
             }
+        }
+
+        /// <summary>
+        /// Handles a click on the notify icon or its balloon.
+        /// </summary>
+        /// <param name="sender">Event source.</param>
+        /// <param name="e">Event arguments.</param>
+        private void HandleNotifyIconOrBalloonClicked(object? sender, EventArgs e)
+        {
+            // Restore the Window
+            this.window.WindowState = WindowState.Normal;
+
+            // If the program was started with the --minimize argument, the Window has not been shown yet.
+            // Show the program and update the tray state one time since the StateChanged event does not fire on show.
+            if (!this.window.IsLoaded)
+            {
+                this.window.Show();
+                UpdateTrayState();
+            }
+
+            this.window.Activate();
         }
     }
 }

--- a/src/AutoCursorLock.App/Views/GeneralSettingsWindow.xaml
+++ b/src/AutoCursorLock.App/Views/GeneralSettingsWindow.xaml
@@ -1,0 +1,34 @@
+﻿<Window x:Class="AutoCursorLock.App.Views.GeneralSettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AutoCursorLock.App.Views"
+        mc:Ignorable="d"
+        Title="General Settings" Height="450" Width="800">
+    <Grid x:Name="mainGrid" ShowGridLines="True">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            Grid.Column="0"
+            Grid.Row="0"
+            Margin="5">
+            Automatically start the application when Windows starts
+        </TextBlock>
+        <CheckBox
+            Grid.Column="1"
+            Grid.Row="0"
+            Margin="5"
+            IsChecked="{Binding StartWithWindows}"
+            Checked="StartWithWindowsCheckBox_Checked"
+            Unchecked="StartWithWindowsCheckBox_Unchecked"/>
+
+    </Grid>
+</Window>

--- a/src/AutoCursorLock.App/Views/GeneralSettingsWindow.xaml.cs
+++ b/src/AutoCursorLock.App/Views/GeneralSettingsWindow.xaml.cs
@@ -1,0 +1,70 @@
+﻿// Copyright(c) James La Novara-Gsell. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace AutoCursorLock.App.Views;
+
+using System;
+using System.Diagnostics;
+using System.Windows;
+
+/// <summary>
+/// Interaction logic for GeneralSettings.xaml.
+/// </summary>
+public partial class GeneralSettingsWindow : Window
+{
+    private readonly string shortcutPath;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeneralSettingsWindow"/> class.
+    /// </summary>
+    public GeneralSettingsWindow()
+    {
+        InitializeComponent();
+
+        // check if the shortcut exists in the startup folder
+        var startupFolder = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
+        this.shortcutPath = System.IO.Path.Combine(startupFolder, "AutoCursorLock.lnk");
+        StartWithWindows = System.IO.File.Exists(this.shortcutPath);
+
+        this.mainGrid.DataContext = this;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to start the application when Windows starts.
+    /// </summary>
+    public bool StartWithWindows { get; set; }
+
+    private void StartWithWindowsCheckBox_Checked(object sender, RoutedEventArgs e)
+    {
+        if (System.IO.File.Exists(this.shortcutPath))
+        {
+            return;
+        }
+
+        // create a shortcut in the startup folder
+        var shortcutPath = this.shortcutPath;
+        var targetPath = Process.GetCurrentProcess().MainModule?.FileName ?? throw new AutoCursorLockException("Could not get entry assembly");
+
+        var shellType = Type.GetTypeFromProgID("WScript.Shell") ?? throw new AutoCursorLockException("Could not get WScript.Shell type");
+
+        // The use of dynamic here is unfortunate, but using the Activator removes a dependency on the IWshRuntimeLibrary
+        // and even if we used the full library, the IWshShell3.CreateShortctut method returns a dynamic...
+        dynamic shell = Activator.CreateInstance(shellType) ?? throw new AutoCursorLockException("Could not create WScript.Shell instance");
+
+        var shortcut = shell.CreateShortcut(shortcutPath);
+        shortcut.Description = "AutoCursorLock";
+        shortcut.TargetPath = targetPath;
+        shortcut.Arguments = "--minimize --quiet";
+        shortcut.Save();
+    }
+
+    private void StartWithWindowsCheckBox_Unchecked(object sender, RoutedEventArgs e)
+    {
+        // delete the shortcut in the startup folder
+        var shortcutPath = this.shortcutPath;
+        if (System.IO.File.Exists(shortcutPath))
+        {
+            System.IO.File.Delete(shortcutPath);
+        }
+    }
+}

--- a/src/AutoCursorLock.App/Views/MainWindow.xaml
+++ b/src/AutoCursorLock.App/Views/MainWindow.xaml
@@ -8,7 +8,6 @@
         xmlns:localExtensions="clr-namespace:AutoCursorLock.App.Extensions"
         xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:models="clr-namespace:AutoCursorLock.App.Models"
         xmlns:sdk="clr-namespace:AutoCursorLock.Sdk.Models;assembly=AutoCursorLock.Sdk"
-        Loaded="Window_Loaded"
         mc:Ignorable="d"
         Title="AutoCursorLock"
         Height="620"
@@ -39,6 +38,10 @@
         </Grid.ColumnDefinitions>
 
         <Menu Grid.Row="0">
+            <MenuItem Header="_File">
+                <MenuItem Header="_Settings"
+                        Click="SettingsItem_Click"/>
+            </MenuItem>
             <MenuItem Header="_Help">
                 <MenuItem Header="_About"
                         Click="AboutItem_Click"/>


### PR DESCRIPTION
Closes #27

Adds an option to General Settings (new window available via File -> Settings) that configures the program to start automatically when Windows starts without outputting any notification about the program minimizing to the tray.

![image](https://github.com/user-attachments/assets/bc962e91-a002-41a7-88f4-c1a2e59ae93c)
