### PR TITLE
fix: Default log level to info and add setting to change it

### DIFF
--- a/src/AutoCursorLock.App/AutoCursorLock.App.csproj
+++ b/src/AutoCursorLock.App/AutoCursorLock.App.csproj
@@ -27,15 +27,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Serilog" Version="4.0.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoCursorLock.App/HostingExtensions.cs
+++ b/src/AutoCursorLock.App/HostingExtensions.cs
@@ -8,6 +8,7 @@ using AutoCursorLock.App.Views;
 using AutoCursorLock.Native;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
+using Serilog.Core;
 
 /// <summary>
 /// Hosting extensions.
@@ -21,11 +22,17 @@ internal static class HostingExtensions
     /// <returns>The service collection with added services.</returns>
     public static IServiceCollection UseAutoCursorLockApp(this IServiceCollection services)
     {
+        var logLevelSwitch = new LoggingLevelSwitch();
+
         Log.Logger = new LoggerConfiguration()
-            .MinimumLevel.Debug()
+            .MinimumLevel.ControlledBy(logLevelSwitch)
             .WriteTo.Console()
             .WriteTo.Debug()
-            .WriteTo.File(Paths.LogPath, retainedFileCountLimit: 5)
+            .WriteTo.File(
+                path: Paths.LogPath,
+                rollingInterval: RollingInterval.Day,
+                retainedFileCountLimit: 1
+            )
             .CreateLogger();
 
         services.UseAutoCursorLockNative();
@@ -34,6 +41,7 @@ internal static class HostingExtensions
             .AddSingleton<MainWindowFactory>()
             .AddSingleton<LoadUserSettingsOperation>()
             .AddSingleton<SaveUserSettingsOperation>()
+            .AddSingleton(logLevelSwitch)
             .AddLogging(b => b
                 .AddSerilog());
 

--- a/src/AutoCursorLock.App/Models/UserSettings.cs
+++ b/src/AutoCursorLock.App/Models/UserSettings.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using AutoCursorLock.Native;
+using Serilog.Core;
+using Serilog.Events;
 
 /// <summary>
 /// Represents the program settings as defined by the user.
@@ -20,10 +22,12 @@ public class UserSettings : INotifyPropertyChanged
     /// </summary>
     /// <param name="enabledProcesses">The processes enabled byh the user.</param>
     /// <param name="hotKey">The hot key to toggle the cursor lock.</param>
-    public UserSettings(ObservableCollection<ProcessListItem> enabledProcesses, HotKey? hotKey)
+    /// <param name="loggingSwitch">The logging level for the application.</param>
+    public UserSettings(ObservableCollection<ProcessListItem> enabledProcesses, HotKey? hotKey, LoggingLevelSwitch loggingSwitch)
     {
         EnabledProcesses = enabledProcesses ?? throw new ArgumentNullException(nameof(enabledProcesses));
         HotKey = hotKey;
+        LoggingSwitch = loggingSwitch;
     }
 
     /// <inheritdoc/>
@@ -54,6 +58,11 @@ public class UserSettings : INotifyPropertyChanged
             NotifyPropertyChanged(nameof(HotKey));
         }
     }
+
+    /// <summary>
+    /// Gets or sets the logging level for the application.
+    /// </summary>
+    public LoggingLevelSwitch LoggingSwitch { get; set; }
 
     private void NotifyPropertyChanged(string propertyName)
     {

--- a/src/AutoCursorLock.App/Models/UserSettingsExtensions.cs
+++ b/src/AutoCursorLock.App/Models/UserSettingsExtensions.cs
@@ -4,9 +4,9 @@
 namespace AutoCursorLock.App.Models;
 
 using AutoCursorLock.Sdk.Models;
+using Serilog.Core;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Linq;
 
 /// <summary>
@@ -18,8 +18,9 @@ public static class UserSettingsExtensions
     /// Converts a <see cref="UserSettingsModel"/> to a <see cref="UserSettings"/>.
     /// </summary>
     /// <param name="userSettingsModel">The model.</param>
+    /// <param name="loggingLevelSwitch">The logging level switch.</param>
     /// <returns>The view model.</returns>
-    public static ConversionResult<UserSettings> ToViewModel(this UserSettingsModel userSettingsModel)
+    public static ConversionResult<UserSettings> ToViewModel(this UserSettingsModel userSettingsModel, LoggingLevelSwitch loggingLevelSwitch)
     {
         var failures = new List<string>();
         var processes = new ObservableCollection<ProcessListItem>();
@@ -37,9 +38,13 @@ public static class UserSettingsExtensions
             }
         }
 
+        // pass the logging switch through, but set the log level beforehand
+        loggingLevelSwitch.MinimumLevel = userSettingsModel.LogLevel;
+
         var userSettings = new UserSettings(
             processes,
-            userSettingsModel.HotKey?.ToViewModel(id: 0)
+            userSettingsModel.HotKey?.ToViewModel(id: 0),
+            loggingLevelSwitch
         );
 
         return new ConversionResult<UserSettings>(userSettings, failures);
@@ -56,6 +61,7 @@ public static class UserSettingsExtensions
         {
             HotKey = userSettings.HotKey?.ToModel(),
             AppLocks = userSettings.EnabledProcesses.Select(p => p.ToModel()).ToArray(),
+            LogLevel = userSettings.LoggingSwitch.MinimumLevel,
         };
     }
 }

--- a/src/AutoCursorLock.App/Services/LoadUserSettingsOperation.cs
+++ b/src/AutoCursorLock.App/Services/LoadUserSettingsOperation.cs
@@ -5,6 +5,7 @@ namespace AutoCursorLock.App.Services;
 
 using AutoCursorLock.Sdk.Models;
 using Microsoft.Extensions.Logging;
+using Serilog.Core;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;

--- a/src/AutoCursorLock.App/Views/GeneralSettingsWindow.xaml
+++ b/src/AutoCursorLock.App/Views/GeneralSettingsWindow.xaml
@@ -30,5 +30,18 @@
             Checked="StartWithWindowsCheckBox_Checked"
             Unchecked="StartWithWindowsCheckBox_Unchecked"/>
 
+        <TextBlock
+            Grid.Column="0"
+            Grid.Row="1"
+            Margin="5">
+            Logging level
+        </TextBlock>
+        <ComboBox
+            Grid.Column="1"
+            Grid.Row="1"
+            Margin="5"
+            ItemsSource="{Binding LogEventLevels}" 
+            SelectedItem="{Binding LogLevel, Mode=TwoWay}" />
+
     </Grid>
 </Window>

--- a/src/AutoCursorLock.App/Views/GeneralSettingsWindow.xaml.cs
+++ b/src/AutoCursorLock.App/Views/GeneralSettingsWindow.xaml.cs
@@ -3,6 +3,10 @@
 
 namespace AutoCursorLock.App.Views;
 
+using AutoCursorLock.App.Models;
+using AutoCursorLock.Sdk.Models;
+using Serilog.Core;
+using Serilog.Events;
 using System;
 using System.Diagnostics;
 using System.Windows;
@@ -14,10 +18,13 @@ public partial class GeneralSettingsWindow : Window
 {
     private readonly string shortcutPath;
 
+    private readonly UserSettings userSettings;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="GeneralSettingsWindow"/> class.
     /// </summary>
-    public GeneralSettingsWindow()
+    /// <param name="userSettings">The user settings model.</param>
+    public GeneralSettingsWindow(UserSettings userSettings)
     {
         InitializeComponent();
 
@@ -27,12 +34,27 @@ public partial class GeneralSettingsWindow : Window
         StartWithWindows = System.IO.File.Exists(this.shortcutPath);
 
         this.mainGrid.DataContext = this;
+        this.userSettings = userSettings;
     }
 
     /// <summary>
     /// Gets or sets a value indicating whether to start the application when Windows starts.
     /// </summary>
     public bool StartWithWindows { get; set; }
+
+    /// <summary>
+    /// Gets or sets the logging level for the application.
+    /// </summary>
+    public LogEventLevel LogLevel
+    {
+        get => this.userSettings.LoggingSwitch.MinimumLevel;
+        set => this.userSettings.LoggingSwitch.MinimumLevel = value;
+    }
+
+    /// <summary>
+    /// Gets the log event levels.
+    /// </summary>
+    public LogEventLevel[] LogEventLevels => Enum.GetValues<LogEventLevel>();
 
     private void StartWithWindowsCheckBox_Checked(object sender, RoutedEventArgs e)
     {

--- a/src/AutoCursorLock.App/Views/MainWindow.xaml.cs
+++ b/src/AutoCursorLock.App/Views/MainWindow.xaml.cs
@@ -400,7 +400,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
 
     private void SettingsItem_Click(object sender, RoutedEventArgs e)
     {
-        var settingsWindow = new GeneralSettingsWindow();
+        var settingsWindow = new GeneralSettingsWindow(UserSettings);
         settingsWindow.ShowDialog();
     }
 }

--- a/src/AutoCursorLock.App/Views/MainWindowFactory.cs
+++ b/src/AutoCursorLock.App/Views/MainWindowFactory.cs
@@ -7,6 +7,7 @@ using AutoCursorLock.App.Models;
 using AutoCursorLock.App.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Serilog.Core;
 using System;
 using System.Threading.Tasks;
 
@@ -15,6 +16,7 @@ using System.Threading.Tasks;
 /// </summary>
 internal class MainWindowFactory(
     LoadUserSettingsOperation loadUserSettingsOperation,
+    LoggingLevelSwitch loggingLevelSwitch,
     ILogger<MainWindowFactory> logger,
     IServiceProvider serviceProvider)
 {
@@ -25,7 +27,7 @@ internal class MainWindowFactory(
     public async Task<MainWindow> CreateAsync()
     {
         var userSettingsModel = await loadUserSettingsOperation.InvokeAsync();
-        var conversionResult = userSettingsModel.ToViewModel();
+        var conversionResult = userSettingsModel.ToViewModel(loggingLevelSwitch);
 
         foreach (var failure in conversionResult.Failures)
         {

--- a/src/AutoCursorLock.Sdk/AutoCursorLock.Sdk.csproj
+++ b/src/AutoCursorLock.Sdk/AutoCursorLock.Sdk.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="4.2.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/AutoCursorLock.Sdk/Models/UserSettingsModel.cs
+++ b/src/AutoCursorLock.Sdk/Models/UserSettingsModel.cs
@@ -3,6 +3,7 @@
 
 namespace AutoCursorLock.Sdk.Models;
 
+using Serilog.Events;
 using System.Text.Json.Serialization;
 
 /// <summary>
@@ -11,12 +12,17 @@ using System.Text.Json.Serialization;
 public record UserSettingsModel
 {
     /// <summary>
-    /// The hot key to use to toggle the cursor lock.
+    /// Gets the hot key to use to toggle the cursor lock.
     /// </summary>
     public HotKeyModel? HotKey { get; init; }
 
     /// <summary>
-    /// The app locks to use.
+    /// Gets the log level.
+    /// </summary>
+    public LogEventLevel LogLevel { get; init; } = LogEventLevel.Information;
+
+    /// <summary>
+    /// Gets the app locks to use.
     /// </summary>
     [JsonRequired]
     required public AppLockSettingsModel[] AppLocks { get; init; }


### PR DESCRIPTION
Now that cursor locks can be reapplied on an interval, debug-level logging was very excessive,
so it has been defaulted to info from now on.

To change it, go to the general settings window.
Changes will be persisted to disk.

Fixes #32

![image](https://github.com/user-attachments/assets/c2245c63-7ae2-4f9a-9c47-a526ea6ff237)